### PR TITLE
Modifications to truncation handler.  

### DIFF
--- a/src/mavlink-v2/mavlink-parser-v2.ts
+++ b/src/mavlink-v2/mavlink-parser-v2.ts
@@ -75,20 +75,18 @@ export class MAVLinkParserV2 extends MAVLinkParserBase {
                 const field_type: string = field[1];
                 const extension_field: boolean = field[2];
                 const field_length = message.sizeof(field_type);
-                if (payload.length > start + field_length) {
+                if (payload.length >= start + field_length) {
                     message[field_name] = this.read(payload, start, field_type);
                     start += field_length;
-                } else {
-                    if (payload.readUInt8(start) === 0) { // payload truncation (last field was zero)
-                        message[field_name] = 0;
-                        start += field_length;
-                    } else { // append the truncated zero bytes so that we can parse the last field
-                        const truncated: Buffer = payload.slice(start);
-                        const filler: Buffer = Buffer.alloc(field_length - truncated.length);
-                        const buf = Buffer.concat([truncated, filler]);
-                        message[field_name] = this.read(buf, 0, field_type);
-                        start += field_length;
-                    }
+                } else if (start < payload.length) { // partially truncated field
+                    const truncated: Buffer = payload.slice(start);
+                    const filler: Buffer = Buffer.alloc(field_length - truncated.length);
+                    const buf = Buffer.concat([truncated, filler]);
+                    message[field_name] = this.read(buf, 0, field_type);
+                    start += field_length;
+                } else { // fully truncated field
+                    message[field_name] = 0;
+                    start += field_length;
                 }
             }
 


### PR DESCRIPTION
Removes `payload.readUInt8(start)` and performs checks solely on payload size, field size, and start position.